### PR TITLE
Replace Attr.Bytes() with Policy.Bytes()

### DIFF
--- a/genl_hub.go
+++ b/genl_hub.go
@@ -220,7 +220,7 @@ func NewGenlHub() (*GenlHub, error) {
 	}()
 
 	self.Add("nlctrl", "notify", self)
-	if res, err := self.Request("nlctrl", CTRL_VERSION, CTRL_CMD_GETFAMILY, syscall.NLM_F_DUMP, nil, nil); err != nil {
+	if res, err := self.Request("nlctrl", CTRL_VERSION, CTRL_CMD_GETFAMILY, syscall.NLM_F_DUMP, nil); err != nil {
 		return nil, err
 	} else {
 		for _, r := range res {
@@ -292,7 +292,7 @@ func (self GenlHub) GenlListen(msg GenlMessage) {
 	self.sync()
 }
 
-func (self GenlHub) Request(family string, version uint8, cmd uint8, flags uint16, payload []byte, attr AttrList) ([]GenlMessage, error) {
+func (self GenlHub) Request(family string, version uint8, cmd uint8, flags uint16, payload []byte) ([]GenlMessage, error) {
 	var familyInfo GenlFamily
 	familyInfoMiss := true
 	self.lock.Lock()
@@ -315,7 +315,6 @@ func (self GenlHub) Request(family string, version uint8, cmd uint8, flags uint1
 		Version: version,
 	}
 	copy(msg[GENL_HDRLEN:], payload)
-	msg = append(msg, attr.Bytes()...)
 
 	if err := func() error {
 		self.lock.Lock()

--- a/rt_hub.go
+++ b/rt_hub.go
@@ -106,7 +106,7 @@ func (self RtHub) Close() {
 	NlSocketFree(self.sock)
 }
 
-func (self RtHub) Request(cmd uint16, flags uint16, payload []byte, attr AttrList) ([]RtMessage, error) {
+func (self RtHub) Request(cmd uint16, flags uint16, payload []byte) ([]RtMessage, error) {
 	res := make(chan RtMessage)
 
 	var msg []byte
@@ -129,7 +129,6 @@ func (self RtHub) Request(cmd uint16, flags uint16, payload []byte, attr AttrLis
 		return nil, fmt.Errorf("unsupported")
 	}
 	copy(msg, payload)
-	msg = append(msg, attr.Bytes()...)
 
 	self.lock.Lock()
 	self.unicast[self.sock.SeqNext] = res


### PR DESCRIPTION
When trying to use nlgo to send genl requests which include attributes in the request message, I was unable to figure out how Attr.Bytes() is supposed to be used; in particular, the following cast:

```
switch SimplePolicy(self.Field()) {
```

doesn't make any semantic sense to me: the `Attr.Header.Type` encoded in the packet is a family/command `Policy` specific enumeration that is not related to the `SimplePolicy` `NLA_*` enumeration.

This commit moves the existing `Attr.Bytes()` method to `SimplePolicy.BytesOne()`, with the `Attr` as an argument, and switching on `self` instead. The recursive `NLA_NESTED` case is replaced with `NestedPolicy.Bytes()`.

I'm somewhat confused re the `Policy.Parse` interface vs the `SimplePolicy.ParseOne` special-cases, so I'm not sure if this new `Bytes()` method should be part of the `Policy` interface or not? The `SimplePolicy.Bytes` method doesn't really make any sense, so it's just a `panic()` here... Removing it makes it impossible to define any `MapPolicy` with attributes...

The `ListPolicy.Bytes()` method is untested, since the genl service that I'm working with doesn't use that, but the new `MapPolicy.Bytes()` here appears to work for me :)

The second commit changes the `GenlHub.Request` and `RtHub.Request` methods to remove the `AttrList` attribute; I couldn't find any example uses of the methods, so I'm not sure how they should be implemented. Either the caller should pack their attributes as the `payload []byte`, or the `Request` method should take both `Policy` and `AttrList` arguments?
