### PR TITLE
Guard familyIds with lock in GenlHub.Family

### DIFF
--- a/genl_hub.go
+++ b/genl_hub.go
@@ -305,11 +305,14 @@ func (self *GenlHub) Family(name string) GenlFamily {
 	self.Add("nlctrl", "notify", cap)
 	defer self.Remove("nlctrl", "notify", cap)
 
+	self.lock.Lock()
 	for _, f := range self.familyIds {
 		if f.Name == name {
+			self.lock.Unlock()
 			return f
 		}
 	}
+	self.lock.Unlock()
 	if err := self.Async(GenlFamilyCtrl.DumpRequest(CTRL_CMD_GETFAMILY), cap); err != nil {
 		log.Print(err)
 	} else {


### PR DESCRIPTION
Without this fix, there are [Data races in the example · Issue #7 · mqliang/libipvs](https://github.com/mqliang/libipvs/issues/7).

With this fix, there are no data races.
```
hnakamur@express:~/go/src/github.com/mqliang/libipvs/example$ go build -race
hnakamur@express:~/go/src/github.com/mqliang/libipvs/example$ sudo ./example
[sudo] password for hnakamur:
libipvs.Info{Version:0x10201, ConnTabSize:0x1000}
[]*libipvs.Service(nil)
[]*libipvs.Service{(*libipvs.Service)(0xc4200fc090)}
[]*libipvs.Destination{(*libipvs.Destination)(0xc4200be100)}
```
