### PR TITLE
fix unexpected exit from recv loop

### DIFF
--- a/genl_hub.go
+++ b/genl_hub.go
@@ -123,7 +123,8 @@ func NewGenlHub() (*GenlHub, error) {
 		for {
 			buf := make([]byte, syscall.Getpagesize())
 			if bufN, _, err := syscall.Recvfrom(self.sock.Fd, buf, syscall.MSG_TRUNC); err != nil {
-				if e, ok := err.(syscall.Errno); ok && e.Temporary() {
+				if e, ok := err.(syscall.Errno); ok && (e.Temporary() || e == syscall.EINVAL) {
+					log.Printf("[genl_hub_loop] recvfrom fails (tmp error): %v, errno: %v", err, e)
 					continue
 				}
 				break


### PR DESCRIPTION
recvfrom all in read loop may fail with EINVAL error and cause exit from
the loop which breaks all following api calls (clients of the library usually see
'genl hub loop exit' message right before lib api stops to work).

at the same time it seems einval might happen at some specific condition related to
updated/deleted real servers (I could not provide clean test case to repro the issue).

it should be safe to treat einval as tmp error and continue the loop since it's happening between completed
send/recv cycles and doesn't corrupt recv flow.